### PR TITLE
add borough to hint

### DIFF
--- a/scripts/stations_json_generator.rb
+++ b/scripts/stations_json_generator.rb
@@ -3,7 +3,7 @@ require 'json'
 
 stations = {}
 
-stations_csv = File.read('data/common/stations.csv')
+stations_csv = File.read('data/common/Stations.csv')
 csv = CSV.parse(stations_csv, headers: true)
 csv.each do |row|
   stations[row['GTFS Stop ID']] = {

--- a/scripts/stations_json_generator.rb
+++ b/scripts/stations_json_generator.rb
@@ -10,6 +10,7 @@ csv.each do |row|
     name: row['Stop Name'].gsub(/ - /, '-').gsub(/-/, '–'),
     longitude: row['GTFS Longitude'].to_f,
     latitude: row['GTFS Latitude'].to_f,
+    borough: row['Borough'],
   }
 end
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -188,7 +188,7 @@ const App = () => {
         <Icon className='float-right' name='chart bar' size='large' link onClick={handleStatsOpen} />
         <Icon className='float-right' name='question circle outline' size='large' link onClick={handleAboutOpen} />
       </Segment>
-      <Header as='h5' textAlign='center' className='hint'>Travel from {stations[solution.origin].name} to {stations[solution.destination].name} using 2 transfers.</Header>
+      <Header as='h5' textAlign='center' className='hint'>Travel from {stations[solution.origin].name} ({stations[solution.origin].borough}) to {stations[solution.destination].name} ({stations[solution.destination].borough}) using 2 transfers.</Header>
       <Segment basic className='game-grid-wrapper'>
         {
           isNotEnoughRoutes &&

--- a/src/data/stations.json
+++ b/src/data/stations.json
@@ -2,2481 +2,2977 @@
   "R01": {
     "name": "Astoria–Ditmars Blvd",
     "longitude": -73.912034,
-    "latitude": 40.775036
+    "latitude": 40.775036,
+    "borough": "Q"
   },
   "R03": {
     "name": "Astoria Blvd",
     "longitude": -73.917843,
-    "latitude": 40.770258
+    "latitude": 40.770258,
+    "borough": "Q"
   },
   "R04": {
     "name": "30 Av",
     "longitude": -73.921479,
-    "latitude": 40.766779
+    "latitude": 40.766779,
+    "borough": "Q"
   },
   "R05": {
     "name": "Broadway",
     "longitude": -73.925508,
-    "latitude": 40.76182
+    "latitude": 40.76182,
+    "borough": "Q"
   },
   "R06": {
     "name": "36 Av",
     "longitude": -73.929575,
-    "latitude": 40.756804
+    "latitude": 40.756804,
+    "borough": "Q"
   },
   "R08": {
     "name": "39 Av–Dutch Kills",
     "longitude": -73.932755,
-    "latitude": 40.752882
+    "latitude": 40.752882,
+    "borough": "Q"
   },
   "R11": {
     "name": "Lexington Av/59 St",
     "longitude": -73.967258,
-    "latitude": 40.76266
+    "latitude": 40.76266,
+    "borough": "M"
   },
   "R13": {
     "name": "5 Av/59 St",
     "longitude": -73.973347,
-    "latitude": 40.764811
+    "latitude": 40.764811,
+    "borough": "M"
   },
   "R14": {
     "name": "57 St–7 Av",
     "longitude": -73.980658,
-    "latitude": 40.764664
+    "latitude": 40.764664,
+    "borough": "M"
   },
   "R15": {
     "name": "49 St",
     "longitude": -73.984139,
-    "latitude": 40.759901
+    "latitude": 40.759901,
+    "borough": "M"
   },
   "R16": {
     "name": "Times Sq–42 St",
     "longitude": -73.986754,
-    "latitude": 40.754672
+    "latitude": 40.754672,
+    "borough": "M"
   },
   "R17": {
     "name": "34 St–Herald Sq",
     "longitude": -73.98795,
-    "latitude": 40.749567
+    "latitude": 40.749567,
+    "borough": "M"
   },
   "R18": {
     "name": "28 St",
     "longitude": -73.988691,
-    "latitude": 40.745494
+    "latitude": 40.745494,
+    "borough": "M"
   },
   "R19": {
     "name": "23 St",
     "longitude": -73.989344,
-    "latitude": 40.741303
+    "latitude": 40.741303,
+    "borough": "M"
   },
   "R20": {
     "name": "14 St–Union Sq",
     "longitude": -73.990568,
-    "latitude": 40.735736
+    "latitude": 40.735736,
+    "borough": "M"
   },
   "R21": {
     "name": "8 St–NYU",
     "longitude": -73.992629,
-    "latitude": 40.730328
+    "latitude": 40.730328,
+    "borough": "M"
   },
   "R22": {
     "name": "Prince St",
     "longitude": -73.997702,
-    "latitude": 40.724329
+    "latitude": 40.724329,
+    "borough": "M"
   },
   "R23": {
     "name": "Canal St",
     "longitude": -74.001775,
-    "latitude": 40.719527
+    "latitude": 40.719527,
+    "borough": "M"
   },
   "Q01": {
     "name": "Canal St",
     "longitude": -74.00046,
-    "latitude": 40.718383
+    "latitude": 40.718383,
+    "borough": "M"
   },
   "R24": {
     "name": "City Hall",
     "longitude": -74.006978,
-    "latitude": 40.713282
+    "latitude": 40.713282,
+    "borough": "M"
   },
   "R25": {
     "name": "Cortlandt St",
     "longitude": -74.011029,
-    "latitude": 40.710668
+    "latitude": 40.710668,
+    "borough": "M"
   },
   "R26": {
     "name": "Rector St",
     "longitude": -74.013342,
-    "latitude": 40.70722
+    "latitude": 40.70722,
+    "borough": "M"
   },
   "R27": {
     "name": "Whitehall St–South Ferry",
     "longitude": -74.012994,
-    "latitude": 40.703087
+    "latitude": 40.703087,
+    "borough": "M"
   },
   "R28": {
     "name": "Court St",
     "longitude": -73.991777,
-    "latitude": 40.6941
+    "latitude": 40.6941,
+    "borough": "Bk"
   },
   "R29": {
     "name": "Jay St–MetroTech",
     "longitude": -73.985942,
-    "latitude": 40.69218
+    "latitude": 40.69218,
+    "borough": "Bk"
   },
   "R30": {
     "name": "DeKalb Av",
     "longitude": -73.981824,
-    "latitude": 40.690635
+    "latitude": 40.690635,
+    "borough": "Bk"
   },
   "R31": {
     "name": "Atlantic Av–Barclays Ctr",
     "longitude": -73.97881,
-    "latitude": 40.683666
+    "latitude": 40.683666,
+    "borough": "Bk"
   },
   "R32": {
     "name": "Union St",
     "longitude": -73.98311,
-    "latitude": 40.677316
+    "latitude": 40.677316,
+    "borough": "Bk"
   },
   "R33": {
     "name": "4 Av–9 St",
     "longitude": -73.988302,
-    "latitude": 40.670847
+    "latitude": 40.670847,
+    "borough": "Bk"
   },
   "R34": {
     "name": "Prospect Av",
     "longitude": -73.992872,
-    "latitude": 40.665414
+    "latitude": 40.665414,
+    "borough": "Bk"
   },
   "R35": {
     "name": "25 St",
     "longitude": -73.998091,
-    "latitude": 40.660397
+    "latitude": 40.660397,
+    "borough": "Bk"
   },
   "R36": {
     "name": "36 St",
     "longitude": -74.003549,
-    "latitude": 40.655144
+    "latitude": 40.655144,
+    "borough": "Bk"
   },
   "R39": {
     "name": "45 St",
     "longitude": -74.010006,
-    "latitude": 40.648939
+    "latitude": 40.648939,
+    "borough": "Bk"
   },
   "R40": {
     "name": "53 St",
     "longitude": -74.014034,
-    "latitude": 40.645069
+    "latitude": 40.645069,
+    "borough": "Bk"
   },
   "R41": {
     "name": "59 St",
     "longitude": -74.017881,
-    "latitude": 40.641362
+    "latitude": 40.641362,
+    "borough": "Bk"
   },
   "R42": {
     "name": "Bay Ridge Av",
     "longitude": -74.023377,
-    "latitude": 40.634967
+    "latitude": 40.634967,
+    "borough": "Bk"
   },
   "R43": {
     "name": "77 St",
     "longitude": -74.02551,
-    "latitude": 40.629742
+    "latitude": 40.629742,
+    "borough": "Bk"
   },
   "R44": {
     "name": "86 St",
     "longitude": -74.028398,
-    "latitude": 40.622687
+    "latitude": 40.622687,
+    "borough": "Bk"
   },
   "R45": {
     "name": "Bay Ridge–95 St",
     "longitude": -74.030876,
-    "latitude": 40.616622
+    "latitude": 40.616622,
+    "borough": "Bk"
   },
   "D24": {
     "name": "Atlantic Av–Barclays Ctr",
     "longitude": -73.97689,
-    "latitude": 40.68446
+    "latitude": 40.68446,
+    "borough": "Bk"
   },
   "D25": {
     "name": "7 Av",
     "longitude": -73.972367,
-    "latitude": 40.67705
+    "latitude": 40.67705,
+    "borough": "Bk"
   },
   "D26": {
     "name": "Prospect Park",
     "longitude": -73.962246,
-    "latitude": 40.661614
+    "latitude": 40.661614,
+    "borough": "Bk"
   },
   "D27": {
     "name": "Parkside Av",
     "longitude": -73.961495,
-    "latitude": 40.655292
+    "latitude": 40.655292,
+    "borough": "Bk"
   },
   "D28": {
     "name": "Church Av",
     "longitude": -73.962982,
-    "latitude": 40.650527
+    "latitude": 40.650527,
+    "borough": "Bk"
   },
   "D29": {
     "name": "Beverley Rd",
     "longitude": -73.964492,
-    "latitude": 40.644031
+    "latitude": 40.644031,
+    "borough": "Bk"
   },
   "D30": {
     "name": "Cortelyou Rd",
     "longitude": -73.963891,
-    "latitude": 40.640927
+    "latitude": 40.640927,
+    "borough": "Bk"
   },
   "D31": {
     "name": "Newkirk Plaza",
     "longitude": -73.962793,
-    "latitude": 40.635082
+    "latitude": 40.635082,
+    "borough": "Bk"
   },
   "D32": {
     "name": "Avenue H",
     "longitude": -73.961639,
-    "latitude": 40.62927
+    "latitude": 40.62927,
+    "borough": "Bk"
   },
   "D33": {
     "name": "Avenue J",
     "longitude": -73.960803,
-    "latitude": 40.625039
+    "latitude": 40.625039,
+    "borough": "Bk"
   },
   "D34": {
     "name": "Avenue M",
     "longitude": -73.959399,
-    "latitude": 40.617618
+    "latitude": 40.617618,
+    "borough": "Bk"
   },
   "D35": {
     "name": "Kings Hwy",
     "longitude": -73.957734,
-    "latitude": 40.60867
+    "latitude": 40.60867,
+    "borough": "Bk"
   },
   "D37": {
     "name": "Avenue U",
     "longitude": -73.955929,
-    "latitude": 40.5993
+    "latitude": 40.5993,
+    "borough": "Bk"
   },
   "D38": {
     "name": "Neck Rd",
     "longitude": -73.955161,
-    "latitude": 40.595246
+    "latitude": 40.595246,
+    "borough": "Bk"
   },
   "D39": {
     "name": "Sheepshead Bay",
     "longitude": -73.954155,
-    "latitude": 40.586896
+    "latitude": 40.586896,
+    "borough": "Bk"
   },
   "D40": {
     "name": "Brighton Beach",
     "longitude": -73.961376,
-    "latitude": 40.577621
+    "latitude": 40.577621,
+    "borough": "Bk"
   },
   "D41": {
     "name": "Ocean Pkwy",
     "longitude": -73.968501,
-    "latitude": 40.576312
+    "latitude": 40.576312,
+    "borough": "Bk"
   },
   "D42": {
     "name": "W 8 St–NY Aquarium",
     "longitude": -73.975939,
-    "latitude": 40.576127
+    "latitude": 40.576127,
+    "borough": "Bk"
   },
   "D43": {
     "name": "Coney Island–Stillwell Av",
     "longitude": -73.981233,
-    "latitude": 40.577422
+    "latitude": 40.577422,
+    "borough": "Bk"
   },
   "B12": {
     "name": "9 Av",
     "longitude": -73.994324,
-    "latitude": 40.646292
+    "latitude": 40.646292,
+    "borough": "Bk"
   },
   "B13": {
     "name": "Fort Hamilton Pkwy",
     "longitude": -73.994304,
-    "latitude": 40.640914
+    "latitude": 40.640914,
+    "borough": "Bk"
   },
   "B14": {
     "name": "50 St",
     "longitude": -73.994791,
-    "latitude": 40.63626
+    "latitude": 40.63626,
+    "borough": "Bk"
   },
   "B15": {
     "name": "55 St",
     "longitude": -73.995476,
-    "latitude": 40.631435
+    "latitude": 40.631435,
+    "borough": "Bk"
   },
   "B16": {
     "name": "62 St",
     "longitude": -73.996895,
-    "latitude": 40.626472
+    "latitude": 40.626472,
+    "borough": "Bk"
   },
   "B17": {
     "name": "71 St",
     "longitude": -73.998864,
-    "latitude": 40.619589
+    "latitude": 40.619589,
+    "borough": "Bk"
   },
   "B18": {
     "name": "79 St",
     "longitude": -74.00061,
-    "latitude": 40.613501
+    "latitude": 40.613501,
+    "borough": "Bk"
   },
   "B19": {
     "name": "18 Av",
     "longitude": -74.001736,
-    "latitude": 40.607954
+    "latitude": 40.607954,
+    "borough": "Bk"
   },
   "B20": {
     "name": "20 Av",
     "longitude": -73.998168,
-    "latitude": 40.604556
+    "latitude": 40.604556,
+    "borough": "Bk"
   },
   "B21": {
     "name": "Bay Pkwy",
     "longitude": -73.993728,
-    "latitude": 40.601875
+    "latitude": 40.601875,
+    "borough": "Bk"
   },
   "B22": {
     "name": "25 Av",
     "longitude": -73.986829,
-    "latitude": 40.597704
+    "latitude": 40.597704,
+    "borough": "Bk"
   },
   "B23": {
     "name": "Bay 50 St",
     "longitude": -73.983765,
-    "latitude": 40.588841
+    "latitude": 40.588841,
+    "borough": "Bk"
   },
   "N02": {
     "name": "8 Av",
     "longitude": -74.011719,
-    "latitude": 40.635064
+    "latitude": 40.635064,
+    "borough": "Bk"
   },
   "N03": {
     "name": "Fort Hamilton Pkwy",
     "longitude": -74.005351,
-    "latitude": 40.631386
+    "latitude": 40.631386,
+    "borough": "Bk"
   },
   "N04": {
     "name": "New Utrecht Av",
     "longitude": -73.996353,
-    "latitude": 40.624842
+    "latitude": 40.624842,
+    "borough": "Bk"
   },
   "N05": {
     "name": "18 Av",
     "longitude": -73.990414,
-    "latitude": 40.620671
+    "latitude": 40.620671,
+    "borough": "Bk"
   },
   "N06": {
     "name": "20 Av",
     "longitude": -73.985026,
-    "latitude": 40.61741
+    "latitude": 40.61741,
+    "borough": "Bk"
   },
   "N07": {
     "name": "Bay Pkwy",
     "longitude": -73.981848,
-    "latitude": 40.611815
+    "latitude": 40.611815,
+    "borough": "Bk"
   },
   "N08": {
     "name": "Kings Hwy",
     "longitude": -73.980353,
-    "latitude": 40.603923
+    "latitude": 40.603923,
+    "borough": "Bk"
   },
   "N09": {
     "name": "Avenue U",
     "longitude": -73.979137,
-    "latitude": 40.597473
+    "latitude": 40.597473,
+    "borough": "Bk"
   },
   "N10": {
     "name": "86 St",
     "longitude": -73.97823,
-    "latitude": 40.592721
+    "latitude": 40.592721,
+    "borough": "Bk"
   },
   "J12": {
     "name": "121 St",
     "longitude": -73.828294,
-    "latitude": 40.700492
+    "latitude": 40.700492,
+    "borough": "Q"
   },
   "J13": {
     "name": "111 St",
     "longitude": -73.836345,
-    "latitude": 40.697418
+    "latitude": 40.697418,
+    "borough": "Q"
   },
   "J14": {
     "name": "104 St",
     "longitude": -73.84433,
-    "latitude": 40.695178
+    "latitude": 40.695178,
+    "borough": "Q"
   },
   "J15": {
     "name": "Woodhaven Blvd",
     "longitude": -73.851576,
-    "latitude": 40.693879
+    "latitude": 40.693879,
+    "borough": "Q"
   },
   "J16": {
     "name": "85 St–Forest Pkwy",
     "longitude": -73.86001,
-    "latitude": 40.692435
+    "latitude": 40.692435,
+    "borough": "Q"
   },
   "J17": {
     "name": "75 St–Elderts Ln",
     "longitude": -73.867139,
-    "latitude": 40.691324
+    "latitude": 40.691324,
+    "borough": "Q"
   },
   "J19": {
     "name": "Cypress Hills",
     "longitude": -73.87255,
-    "latitude": 40.689941
+    "latitude": 40.689941,
+    "borough": "Bk"
   },
   "J20": {
     "name": "Crescent St",
     "longitude": -73.873785,
-    "latitude": 40.683194
+    "latitude": 40.683194,
+    "borough": "Bk"
   },
   "J21": {
     "name": "Norwood Av",
     "longitude": -73.880039,
-    "latitude": 40.68141
+    "latitude": 40.68141,
+    "borough": "Bk"
   },
   "J22": {
     "name": "Cleveland St",
     "longitude": -73.884639,
-    "latitude": 40.679947
+    "latitude": 40.679947,
+    "borough": "Bk"
   },
   "J23": {
     "name": "Van Siclen Av",
     "longitude": -73.891688,
-    "latitude": 40.678024
+    "latitude": 40.678024,
+    "borough": "Bk"
   },
   "J24": {
     "name": "Alabama Av",
     "longitude": -73.898654,
-    "latitude": 40.676992
+    "latitude": 40.676992,
+    "borough": "Bk"
   },
   "J27": {
     "name": "Broadway Junction",
     "longitude": -73.904512,
-    "latitude": 40.679498
+    "latitude": 40.679498,
+    "borough": "Bk"
   },
   "J28": {
     "name": "Chauncey St",
     "longitude": -73.910456,
-    "latitude": 40.682893
+    "latitude": 40.682893,
+    "borough": "Bk"
   },
   "J29": {
     "name": "Halsey St",
     "longitude": -73.916559,
-    "latitude": 40.68637
+    "latitude": 40.68637,
+    "borough": "Bk"
   },
   "J30": {
     "name": "Gates Av",
     "longitude": -73.92227,
-    "latitude": 40.68963
+    "latitude": 40.68963,
+    "borough": "Bk"
   },
   "J31": {
     "name": "Kosciuszko St",
     "longitude": -73.928814,
-    "latitude": 40.693342
+    "latitude": 40.693342,
+    "borough": "Bk"
   },
   "M11": {
     "name": "Myrtle Av",
     "longitude": -73.935657,
-    "latitude": 40.697207
+    "latitude": 40.697207,
+    "borough": "Bk"
   },
   "M12": {
     "name": "Flushing Av",
     "longitude": -73.941126,
-    "latitude": 40.70026
+    "latitude": 40.70026,
+    "borough": "Bk"
   },
   "M13": {
     "name": "Lorimer St",
     "longitude": -73.947408,
-    "latitude": 40.703869
+    "latitude": 40.703869,
+    "borough": "Bk"
   },
   "M14": {
     "name": "Hewes St",
     "longitude": -73.953431,
-    "latitude": 40.70687
+    "latitude": 40.70687,
+    "borough": "Bk"
   },
   "M16": {
     "name": "Marcy Av",
     "longitude": -73.957757,
-    "latitude": 40.708359
+    "latitude": 40.708359,
+    "borough": "Bk"
   },
   "M18": {
     "name": "Delancey St–Essex St",
     "longitude": -73.987437,
-    "latitude": 40.718315
+    "latitude": 40.718315,
+    "borough": "M"
   },
   "M19": {
     "name": "Bowery",
     "longitude": -73.993915,
-    "latitude": 40.72028
+    "latitude": 40.72028,
+    "borough": "M"
   },
   "M20": {
     "name": "Canal St",
     "longitude": -73.999892,
-    "latitude": 40.718092
+    "latitude": 40.718092,
+    "borough": "M"
   },
   "M21": {
     "name": "Chambers St",
     "longitude": -74.003401,
-    "latitude": 40.713243
+    "latitude": 40.713243,
+    "borough": "M"
   },
   "M22": {
     "name": "Fulton St",
     "longitude": -74.007582,
-    "latitude": 40.710374
+    "latitude": 40.710374,
+    "borough": "M"
   },
   "M23": {
     "name": "Broad St",
     "longitude": -74.011056,
-    "latitude": 40.706476
+    "latitude": 40.706476,
+    "borough": "M"
   },
   "M01": {
     "name": "Middle Village–Metropolitan Av",
     "longitude": -73.889601,
-    "latitude": 40.711396
+    "latitude": 40.711396,
+    "borough": "Q"
   },
   "M04": {
     "name": "Fresh Pond Rd",
     "longitude": -73.895877,
-    "latitude": 40.706186
+    "latitude": 40.706186,
+    "borough": "Q"
   },
   "M05": {
     "name": "Forest Av",
     "longitude": -73.903077,
-    "latitude": 40.704423
+    "latitude": 40.704423,
+    "borough": "Q"
   },
   "M06": {
     "name": "Seneca Av",
     "longitude": -73.90774,
-    "latitude": 40.702762
+    "latitude": 40.702762,
+    "borough": "Q"
   },
   "M08": {
     "name": "Myrtle–Wyckoff Avs",
     "longitude": -73.912385,
-    "latitude": 40.69943
+    "latitude": 40.69943,
+    "borough": "Bk"
   },
   "M09": {
     "name": "Knickerbocker Av",
     "longitude": -73.919711,
-    "latitude": 40.698664
+    "latitude": 40.698664,
+    "borough": "Bk"
   },
   "M10": {
     "name": "Central Av",
     "longitude": -73.927397,
-    "latitude": 40.697857
+    "latitude": 40.697857,
+    "borough": "Bk"
   },
   "L01": {
     "name": "8 Av",
     "longitude": -74.002578,
-    "latitude": 40.739777
+    "latitude": 40.739777,
+    "borough": "M"
   },
   "L02": {
     "name": "6 Av",
     "longitude": -73.996786,
-    "latitude": 40.737335
+    "latitude": 40.737335,
+    "borough": "M"
   },
   "L03": {
     "name": "14 St–Union Sq.",
     "longitude": -73.99073,
-    "latitude": 40.734789
+    "latitude": 40.734789,
+    "borough": "M"
   },
   "L05": {
     "name": "3 Av",
     "longitude": -73.986122,
-    "latitude": 40.732849
+    "latitude": 40.732849,
+    "borough": "M"
   },
   "L06": {
     "name": "1 Av",
     "longitude": -73.981628,
-    "latitude": 40.730953
+    "latitude": 40.730953,
+    "borough": "M"
   },
   "L08": {
     "name": "Bedford Av",
     "longitude": -73.956872,
-    "latitude": 40.717304
+    "latitude": 40.717304,
+    "borough": "Bk"
   },
   "L10": {
     "name": "Lorimer St",
     "longitude": -73.950275,
-    "latitude": 40.714063
+    "latitude": 40.714063,
+    "borough": "Bk"
   },
   "L11": {
     "name": "Graham Av",
     "longitude": -73.944053,
-    "latitude": 40.714565
+    "latitude": 40.714565,
+    "borough": "Bk"
   },
   "L12": {
     "name": "Grand St",
     "longitude": -73.94067,
-    "latitude": 40.711926
+    "latitude": 40.711926,
+    "borough": "Bk"
   },
   "L13": {
     "name": "Montrose Av",
     "longitude": -73.93985,
-    "latitude": 40.707739
+    "latitude": 40.707739,
+    "borough": "Bk"
   },
   "L14": {
     "name": "Morgan Av",
     "longitude": -73.933147,
-    "latitude": 40.706152
+    "latitude": 40.706152,
+    "borough": "Bk"
   },
   "L15": {
     "name": "Jefferson St",
     "longitude": -73.922913,
-    "latitude": 40.706607
+    "latitude": 40.706607,
+    "borough": "Bk"
   },
   "L16": {
     "name": "DeKalb Av",
     "longitude": -73.918425,
-    "latitude": 40.703811
+    "latitude": 40.703811,
+    "borough": "Bk"
   },
   "L17": {
     "name": "Myrtle–Wyckoff Avs",
     "longitude": -73.911586,
-    "latitude": 40.699814
+    "latitude": 40.699814,
+    "borough": "Bk"
   },
   "L19": {
     "name": "Halsey St",
     "longitude": -73.904084,
-    "latitude": 40.695602
+    "latitude": 40.695602,
+    "borough": "Q"
   },
   "L20": {
     "name": "Wilson Av",
     "longitude": -73.904046,
-    "latitude": 40.688764
+    "latitude": 40.688764,
+    "borough": "Bk"
   },
   "L21": {
     "name": "Bushwick Av–Aberdeen St",
     "longitude": -73.905249,
-    "latitude": 40.682829
+    "latitude": 40.682829,
+    "borough": "Bk"
   },
   "L22": {
     "name": "Broadway Junction",
     "longitude": -73.90324,
-    "latitude": 40.678856
+    "latitude": 40.678856,
+    "borough": "Bk"
   },
   "L24": {
     "name": "Atlantic Av",
     "longitude": -73.903097,
-    "latitude": 40.675345
+    "latitude": 40.675345,
+    "borough": "Bk"
   },
   "L25": {
     "name": "Sutter Av",
     "longitude": -73.901975,
-    "latitude": 40.669367
+    "latitude": 40.669367,
+    "borough": "Bk"
   },
   "L26": {
     "name": "Livonia Av",
     "longitude": -73.900571,
-    "latitude": 40.664038
+    "latitude": 40.664038,
+    "borough": "Bk"
   },
   "L27": {
     "name": "New Lots Av",
     "longitude": -73.899232,
-    "latitude": 40.658733
+    "latitude": 40.658733,
+    "borough": "Bk"
   },
   "L28": {
     "name": "East 105 St",
     "longitude": -73.899485,
-    "latitude": 40.650573
+    "latitude": 40.650573,
+    "borough": "Bk"
   },
   "L29": {
     "name": "Canarsie–Rockaway Pkwy",
     "longitude": -73.90185,
-    "latitude": 40.646654
+    "latitude": 40.646654,
+    "borough": "Bk"
   },
   "S01": {
     "name": "Franklin Av",
     "longitude": -73.955827,
-    "latitude": 40.680596
+    "latitude": 40.680596,
+    "borough": "Bk"
   },
   "S03": {
     "name": "Park Pl",
     "longitude": -73.957624,
-    "latitude": 40.674772
+    "latitude": 40.674772,
+    "borough": "Bk"
   },
   "S04": {
     "name": "Botanic Garden",
     "longitude": -73.959245,
-    "latitude": 40.670343
+    "latitude": 40.670343,
+    "borough": "Bk"
   },
   "A02": {
     "name": "Inwood–207 St",
     "longitude": -73.919899,
-    "latitude": 40.868072
+    "latitude": 40.868072,
+    "borough": "M"
   },
   "A03": {
     "name": "Dyckman St",
     "longitude": -73.927271,
-    "latitude": 40.865491
+    "latitude": 40.865491,
+    "borough": "M"
   },
   "A05": {
     "name": "190 St",
     "longitude": -73.93418,
-    "latitude": 40.859022
+    "latitude": 40.859022,
+    "borough": "M"
   },
   "A06": {
     "name": "181 St",
     "longitude": -73.937969,
-    "latitude": 40.851695
+    "latitude": 40.851695,
+    "borough": "M"
   },
   "A07": {
     "name": "175 St",
     "longitude": -73.939704,
-    "latitude": 40.847391
+    "latitude": 40.847391,
+    "borough": "M"
   },
   "A09": {
     "name": "168 St",
     "longitude": -73.939561,
-    "latitude": 40.840719
+    "latitude": 40.840719,
+    "borough": "M"
   },
   "A10": {
     "name": "163 St–Amsterdam Av",
     "longitude": -73.939892,
-    "latitude": 40.836013
+    "latitude": 40.836013,
+    "borough": "M"
   },
   "A11": {
     "name": "155 St",
     "longitude": -73.941514,
-    "latitude": 40.830518
+    "latitude": 40.830518,
+    "borough": "M"
   },
   "A12": {
     "name": "145 St",
     "longitude": -73.944216,
-    "latitude": 40.824783
+    "latitude": 40.824783,
+    "borough": "M"
   },
   "D13": {
     "name": "145 St",
     "longitude": -73.944216,
-    "latitude": 40.824783
+    "latitude": 40.824783,
+    "borough": "M"
   },
   "A14": {
     "name": "135 St",
     "longitude": -73.947649,
-    "latitude": 40.817894
+    "latitude": 40.817894,
+    "borough": "M"
   },
   "A15": {
     "name": "125 St",
     "longitude": -73.952343,
-    "latitude": 40.811109
+    "latitude": 40.811109,
+    "borough": "M"
   },
   "A16": {
     "name": "116 St",
     "longitude": -73.954882,
-    "latitude": 40.805085
+    "latitude": 40.805085,
+    "borough": "M"
   },
   "A17": {
     "name": "Cathedral Pkwy (110 St)",
     "longitude": -73.958161,
-    "latitude": 40.800603
+    "latitude": 40.800603,
+    "borough": "M"
   },
   "A18": {
     "name": "103 St",
     "longitude": -73.961454,
-    "latitude": 40.796092
+    "latitude": 40.796092,
+    "borough": "M"
   },
   "A19": {
     "name": "96 St",
     "longitude": -73.964696,
-    "latitude": 40.791642
+    "latitude": 40.791642,
+    "borough": "M"
   },
   "A20": {
     "name": "86 St",
     "longitude": -73.968916,
-    "latitude": 40.785868
+    "latitude": 40.785868,
+    "borough": "M"
   },
   "A21": {
     "name": "81 St–Museum of Natural History",
     "longitude": -73.972143,
-    "latitude": 40.781433
+    "latitude": 40.781433,
+    "borough": "M"
   },
   "A22": {
     "name": "72 St",
     "longitude": -73.97641,
-    "latitude": 40.775594
+    "latitude": 40.775594,
+    "borough": "M"
   },
   "A24": {
     "name": "59 St–Columbus Circle",
     "longitude": -73.981736,
-    "latitude": 40.768296
+    "latitude": 40.768296,
+    "borough": "M"
   },
   "A25": {
     "name": "50 St",
     "longitude": -73.985984,
-    "latitude": 40.762456
+    "latitude": 40.762456,
+    "borough": "M"
   },
   "A27": {
     "name": "42 St–Port Authority Bus Terminal",
     "longitude": -73.989735,
-    "latitude": 40.757308
+    "latitude": 40.757308,
+    "borough": "M"
   },
   "A28": {
     "name": "34 St–Penn Station",
     "longitude": -73.993391,
-    "latitude": 40.752287
+    "latitude": 40.752287,
+    "borough": "M"
   },
   "A30": {
     "name": "23 St",
     "longitude": -73.998041,
-    "latitude": 40.745906
+    "latitude": 40.745906,
+    "borough": "M"
   },
   "A31": {
     "name": "14 St",
     "longitude": -74.00169,
-    "latitude": 40.740893
+    "latitude": 40.740893,
+    "borough": "M"
   },
   "A32": {
     "name": "W 4 St–Wash Sq",
     "longitude": -74.000495,
-    "latitude": 40.732338
+    "latitude": 40.732338,
+    "borough": "M"
   },
   "D20": {
     "name": "W 4 St–Wash Sq",
     "longitude": -74.000495,
-    "latitude": 40.732338
+    "latitude": 40.732338,
+    "borough": "M"
   },
   "A33": {
     "name": "Spring St",
     "longitude": -74.003739,
-    "latitude": 40.726227
+    "latitude": 40.726227,
+    "borough": "M"
   },
   "A34": {
     "name": "Canal St",
     "longitude": -74.005229,
-    "latitude": 40.720824
+    "latitude": 40.720824,
+    "borough": "M"
   },
   "A36": {
     "name": "Chambers St",
     "longitude": -74.008585,
-    "latitude": 40.714111
+    "latitude": 40.714111,
+    "borough": "M"
   },
   "E01": {
     "name": "World Trade Center",
     "longitude": -74.009781,
-    "latitude": 40.712582
+    "latitude": 40.712582,
+    "borough": "M"
   },
   "A38": {
     "name": "Fulton St",
     "longitude": -74.007691,
-    "latitude": 40.710197
+    "latitude": 40.710197,
+    "borough": "M"
   },
   "A40": {
     "name": "High St",
     "longitude": -73.990531,
-    "latitude": 40.699337
+    "latitude": 40.699337,
+    "borough": "Bk"
   },
   "A41": {
     "name": "Jay St–MetroTech",
     "longitude": -73.987342,
-    "latitude": 40.692338
+    "latitude": 40.692338,
+    "borough": "Bk"
   },
   "A42": {
     "name": "Hoyt–Schermerhorn Sts",
     "longitude": -73.985001,
-    "latitude": 40.688484
+    "latitude": 40.688484,
+    "borough": "Bk"
   },
   "A43": {
     "name": "Lafayette Av",
     "longitude": -73.973946,
-    "latitude": 40.686113
+    "latitude": 40.686113,
+    "borough": "Bk"
   },
   "A44": {
     "name": "Clinton–Washington Avs",
     "longitude": -73.965838,
-    "latitude": 40.683263
+    "latitude": 40.683263,
+    "borough": "Bk"
   },
   "A45": {
     "name": "Franklin Av",
     "longitude": -73.956848,
-    "latitude": 40.68138
+    "latitude": 40.68138,
+    "borough": "Bk"
   },
   "A46": {
     "name": "Nostrand Av",
     "longitude": -73.950426,
-    "latitude": 40.680438
+    "latitude": 40.680438,
+    "borough": "Bk"
   },
   "A47": {
     "name": "Kingston–Throop Avs",
     "longitude": -73.940858,
-    "latitude": 40.679921
+    "latitude": 40.679921,
+    "borough": "Bk"
   },
   "A48": {
     "name": "Utica Av",
     "longitude": -73.930729,
-    "latitude": 40.679364
+    "latitude": 40.679364,
+    "borough": "Bk"
   },
   "A49": {
     "name": "Ralph Av",
     "longitude": -73.920786,
-    "latitude": 40.678822
+    "latitude": 40.678822,
+    "borough": "Bk"
   },
   "A50": {
     "name": "Rockaway Av",
     "longitude": -73.911946,
-    "latitude": 40.67834
+    "latitude": 40.67834,
+    "borough": "Bk"
   },
   "A51": {
     "name": "Broadway Junction",
     "longitude": -73.905316,
-    "latitude": 40.678334
+    "latitude": 40.678334,
+    "borough": "Bk"
   },
   "A52": {
     "name": "Liberty Av",
     "longitude": -73.896548,
-    "latitude": 40.674542
+    "latitude": 40.674542,
+    "borough": "Bk"
   },
   "A53": {
     "name": "Van Siclen Av",
     "longitude": -73.890358,
-    "latitude": 40.67271
+    "latitude": 40.67271,
+    "borough": "Bk"
   },
   "A54": {
     "name": "Shepherd Av",
     "longitude": -73.88075,
-    "latitude": 40.67413
+    "latitude": 40.67413,
+    "borough": "Bk"
   },
   "A55": {
     "name": "Euclid Av",
     "longitude": -73.872106,
-    "latitude": 40.675377
+    "latitude": 40.675377,
+    "borough": "Bk"
   },
   "A57": {
     "name": "Grant Av",
     "longitude": -73.86505,
-    "latitude": 40.677044
+    "latitude": 40.677044,
+    "borough": "Bk"
   },
   "A59": {
     "name": "80 St",
     "longitude": -73.858992,
-    "latitude": 40.679371
+    "latitude": 40.679371,
+    "borough": "Q"
   },
   "A60": {
     "name": "88 St",
     "longitude": -73.85147,
-    "latitude": 40.679843
+    "latitude": 40.679843,
+    "borough": "Q"
   },
   "A61": {
     "name": "Rockaway Blvd",
     "longitude": -73.843853,
-    "latitude": 40.680429
+    "latitude": 40.680429,
+    "borough": "Q"
   },
   "A63": {
     "name": "104 St",
     "longitude": -73.837683,
-    "latitude": 40.681711
+    "latitude": 40.681711,
+    "borough": "Q"
   },
   "A64": {
     "name": "111 St",
     "longitude": -73.832163,
-    "latitude": 40.684331
+    "latitude": 40.684331,
+    "borough": "Q"
   },
   "A65": {
     "name": "Ozone Park–Lefferts Blvd",
     "longitude": -73.825798,
-    "latitude": 40.685951
+    "latitude": 40.685951,
+    "borough": "Q"
   },
   "H01": {
     "name": "Aqueduct Racetrack",
     "longitude": -73.835919,
-    "latitude": 40.672097
+    "latitude": 40.672097,
+    "borough": "Q"
   },
   "H02": {
     "name": "Aqueduct–N Conduit Av",
     "longitude": -73.834058,
-    "latitude": 40.668234
+    "latitude": 40.668234,
+    "borough": "Q"
   },
   "H03": {
     "name": "Howard Beach–JFK Airport",
     "longitude": -73.830301,
-    "latitude": 40.660476
+    "latitude": 40.660476,
+    "borough": "Q"
   },
   "H04": {
     "name": "Broad Channel",
     "longitude": -73.815925,
-    "latitude": 40.608382
+    "latitude": 40.608382,
+    "borough": "Q"
   },
   "H12": {
     "name": "Beach 90 St",
     "longitude": -73.813641,
-    "latitude": 40.588034
+    "latitude": 40.588034,
+    "borough": "Q"
   },
   "H13": {
     "name": "Beach 98 St",
     "longitude": -73.820558,
-    "latitude": 40.585307
+    "latitude": 40.585307,
+    "borough": "Q"
   },
   "H14": {
     "name": "Beach 105 St",
     "longitude": -73.827559,
-    "latitude": 40.583209
+    "latitude": 40.583209,
+    "borough": "Q"
   },
   "H15": {
     "name": "Rockaway Park–Beach 116 St",
     "longitude": -73.835592,
-    "latitude": 40.580903
+    "latitude": 40.580903,
+    "borough": "Q"
   },
   "H06": {
     "name": "Beach 67 St",
     "longitude": -73.796924,
-    "latitude": 40.590927
+    "latitude": 40.590927,
+    "borough": "Q"
   },
   "H07": {
     "name": "Beach 60 St",
     "longitude": -73.788522,
-    "latitude": 40.592374
+    "latitude": 40.592374,
+    "borough": "Q"
   },
   "H08": {
     "name": "Beach 44 St",
     "longitude": -73.776013,
-    "latitude": 40.592943
+    "latitude": 40.592943,
+    "borough": "Q"
   },
   "H09": {
     "name": "Beach 36 St",
     "longitude": -73.768175,
-    "latitude": 40.595398
+    "latitude": 40.595398,
+    "borough": "Q"
   },
   "H10": {
     "name": "Beach 25 St",
     "longitude": -73.761353,
-    "latitude": 40.600066
+    "latitude": 40.600066,
+    "borough": "Q"
   },
   "H11": {
     "name": "Far Rockaway–Mott Av",
     "longitude": -73.755405,
-    "latitude": 40.603995
+    "latitude": 40.603995,
+    "borough": "Q"
   },
   "D01": {
     "name": "Norwood–205 St",
     "longitude": -73.878855,
-    "latitude": 40.874811
+    "latitude": 40.874811,
+    "borough": "Bx"
   },
   "D03": {
     "name": "Bedford Park Blvd",
     "longitude": -73.887138,
-    "latitude": 40.873244
+    "latitude": 40.873244,
+    "borough": "Bx"
   },
   "D04": {
     "name": "Kingsbridge Rd",
     "longitude": -73.893509,
-    "latitude": 40.866978
+    "latitude": 40.866978,
+    "borough": "Bx"
   },
   "D05": {
     "name": "Fordham Rd",
     "longitude": -73.897749,
-    "latitude": 40.861296
+    "latitude": 40.861296,
+    "borough": "Bx"
   },
   "D06": {
     "name": "182–183 Sts",
     "longitude": -73.900741,
-    "latitude": 40.856093
+    "latitude": 40.856093,
+    "borough": "Bx"
   },
   "D07": {
     "name": "Tremont Av",
     "longitude": -73.905227,
-    "latitude": 40.85041
+    "latitude": 40.85041,
+    "borough": "Bx"
   },
   "D08": {
     "name": "174–175 Sts",
     "longitude": -73.910136,
-    "latitude": 40.8459
+    "latitude": 40.8459,
+    "borough": "Bx"
   },
   "D09": {
     "name": "170 St",
     "longitude": -73.9134,
-    "latitude": 40.839306
+    "latitude": 40.839306,
+    "borough": "Bx"
   },
   "D10": {
     "name": "167 St",
     "longitude": -73.91844,
-    "latitude": 40.833771
+    "latitude": 40.833771,
+    "borough": "Bx"
   },
   "D11": {
     "name": "161 St–Yankee Stadium",
     "longitude": -73.925651,
-    "latitude": 40.827905
+    "latitude": 40.827905,
+    "borough": "Bx"
   },
   "D12": {
     "name": "155 St",
     "longitude": -73.938209,
-    "latitude": 40.830135
+    "latitude": 40.830135,
+    "borough": "M"
   },
   "B04": {
     "name": "21 St–Queensbridge",
     "longitude": -73.942836,
-    "latitude": 40.754203
+    "latitude": 40.754203,
+    "borough": "Q"
   },
   "B06": {
     "name": "Roosevelt Island",
     "longitude": -73.95326,
-    "latitude": 40.759145
+    "latitude": 40.759145,
+    "borough": "M"
   },
   "B08": {
     "name": "Lexington Av/63 St",
     "longitude": -73.966113,
-    "latitude": 40.764629
+    "latitude": 40.764629,
+    "borough": "M"
   },
   "B10": {
     "name": "57 St",
     "longitude": -73.97745,
-    "latitude": 40.763972
+    "latitude": 40.763972,
+    "borough": "M"
   },
   "D15": {
     "name": "47–50 Sts–Rockefeller Ctr",
     "longitude": -73.981329,
-    "latitude": 40.758663
+    "latitude": 40.758663,
+    "borough": "M"
   },
   "D16": {
     "name": "42 St–Bryant Pk",
     "longitude": -73.984569,
-    "latitude": 40.754222
+    "latitude": 40.754222,
+    "borough": "M"
   },
   "D17": {
     "name": "34 St–Herald Sq",
     "longitude": -73.987823,
-    "latitude": 40.749719
+    "latitude": 40.749719,
+    "borough": "M"
   },
   "D18": {
     "name": "23 St",
     "longitude": -73.992821,
-    "latitude": 40.742878
+    "latitude": 40.742878,
+    "borough": "M"
   },
   "D19": {
     "name": "14 St",
     "longitude": -73.996209,
-    "latitude": 40.738228
+    "latitude": 40.738228,
+    "borough": "M"
   },
   "D21": {
     "name": "Broadway–Lafayette St",
     "longitude": -73.996204,
-    "latitude": 40.725297
+    "latitude": 40.725297,
+    "borough": "M"
   },
   "D22": {
     "name": "Grand St",
     "longitude": -73.993753,
-    "latitude": 40.718267
+    "latitude": 40.718267,
+    "borough": "M"
   },
   "F14": {
     "name": "2 Av",
     "longitude": -73.989938,
-    "latitude": 40.723402
+    "latitude": 40.723402,
+    "borough": "M"
   },
   "F15": {
     "name": "Delancey St–Essex St",
     "longitude": -73.988114,
-    "latitude": 40.718611
+    "latitude": 40.718611,
+    "borough": "M"
   },
   "F16": {
     "name": "East Broadway",
     "longitude": -73.990173,
-    "latitude": 40.713715
+    "latitude": 40.713715,
+    "borough": "M"
   },
   "F18": {
     "name": "York St",
     "longitude": -73.986751,
-    "latitude": 40.701397
+    "latitude": 40.701397,
+    "borough": "Bk"
   },
   "F20": {
     "name": "Bergen St",
     "longitude": -73.990862,
-    "latitude": 40.686145
+    "latitude": 40.686145,
+    "borough": "Bk"
   },
   "F21": {
     "name": "Carroll St",
     "longitude": -73.995048,
-    "latitude": 40.680303
+    "latitude": 40.680303,
+    "borough": "Bk"
   },
   "F22": {
     "name": "Smith–9 Sts",
     "longitude": -73.995959,
-    "latitude": 40.67358
+    "latitude": 40.67358,
+    "borough": "Bk"
   },
   "F23": {
     "name": "4 Av–9 St",
     "longitude": -73.989779,
-    "latitude": 40.670272
+    "latitude": 40.670272,
+    "borough": "Bk"
   },
   "F24": {
     "name": "7 Av",
     "longitude": -73.980305,
-    "latitude": 40.666271
+    "latitude": 40.666271,
+    "borough": "Bk"
   },
   "F25": {
     "name": "15 St–Prospect Park",
     "longitude": -73.979493,
-    "latitude": 40.660365
+    "latitude": 40.660365,
+    "borough": "Bk"
   },
   "F26": {
     "name": "Fort Hamilton Pkwy",
     "longitude": -73.975776,
-    "latitude": 40.650782
+    "latitude": 40.650782,
+    "borough": "Bk"
   },
   "F27": {
     "name": "Church Av",
     "longitude": -73.979678,
-    "latitude": 40.644041
+    "latitude": 40.644041,
+    "borough": "Bk"
   },
   "F29": {
     "name": "Ditmas Av",
     "longitude": -73.978172,
-    "latitude": 40.636119
+    "latitude": 40.636119,
+    "borough": "Bk"
   },
   "F30": {
     "name": "18 Av",
     "longitude": -73.976971,
-    "latitude": 40.629755
+    "latitude": 40.629755,
+    "borough": "Bk"
   },
   "F31": {
     "name": "Avenue I",
     "longitude": -73.976127,
-    "latitude": 40.625322
+    "latitude": 40.625322,
+    "borough": "Bk"
   },
   "F32": {
     "name": "Bay Pkwy",
     "longitude": -73.975264,
-    "latitude": 40.620769
+    "latitude": 40.620769,
+    "borough": "Bk"
   },
   "F33": {
     "name": "Avenue N",
     "longitude": -73.974197,
-    "latitude": 40.61514
+    "latitude": 40.61514,
+    "borough": "Bk"
   },
   "F34": {
     "name": "Avenue P",
     "longitude": -73.973022,
-    "latitude": 40.608944
+    "latitude": 40.608944,
+    "borough": "Bk"
   },
   "F35": {
     "name": "Kings Hwy",
     "longitude": -73.972361,
-    "latitude": 40.603217
+    "latitude": 40.603217,
+    "borough": "Bk"
   },
   "F36": {
     "name": "Avenue U",
     "longitude": -73.973357,
-    "latitude": 40.596063
+    "latitude": 40.596063,
+    "borough": "Bk"
   },
   "F38": {
     "name": "Avenue X",
     "longitude": -73.97425,
-    "latitude": 40.58962
+    "latitude": 40.58962,
+    "borough": "Bk"
   },
   "F39": {
     "name": "Neptune Av",
     "longitude": -73.974574,
-    "latitude": 40.581011
+    "latitude": 40.581011,
+    "borough": "Bk"
   },
   "F01": {
     "name": "Jamaica–179 St",
     "longitude": -73.783817,
-    "latitude": 40.712646
+    "latitude": 40.712646,
+    "borough": "Q"
   },
   "F02": {
     "name": "169 St",
     "longitude": -73.793604,
-    "latitude": 40.71047
+    "latitude": 40.71047,
+    "borough": "Q"
   },
   "F03": {
     "name": "Parsons Blvd",
     "longitude": -73.803326,
-    "latitude": 40.707564
+    "latitude": 40.707564,
+    "borough": "Q"
   },
   "F04": {
     "name": "Sutphin Blvd",
     "longitude": -73.810708,
-    "latitude": 40.70546
+    "latitude": 40.70546,
+    "borough": "Q"
   },
   "F05": {
     "name": "Briarwood",
     "longitude": -73.820574,
-    "latitude": 40.709179
+    "latitude": 40.709179,
+    "borough": "Q"
   },
   "F06": {
     "name": "Kew Gardens–Union Tpke",
     "longitude": -73.831008,
-    "latitude": 40.714441
+    "latitude": 40.714441,
+    "borough": "Q"
   },
   "F07": {
     "name": "75 Av",
     "longitude": -73.837324,
-    "latitude": 40.718331
+    "latitude": 40.718331,
+    "borough": "Q"
   },
   "G08": {
     "name": "Forest Hills–71 Av",
     "longitude": -73.844521,
-    "latitude": 40.721691
+    "latitude": 40.721691,
+    "borough": "Q"
   },
   "G09": {
     "name": "67 Av",
     "longitude": -73.852719,
-    "latitude": 40.726523
+    "latitude": 40.726523,
+    "borough": "Q"
   },
   "G10": {
     "name": "63 Dr–Rego Park",
     "longitude": -73.861604,
-    "latitude": 40.729846
+    "latitude": 40.729846,
+    "borough": "Q"
   },
   "G11": {
     "name": "Woodhaven Blvd",
     "longitude": -73.869229,
-    "latitude": 40.733106
+    "latitude": 40.733106,
+    "borough": "Q"
   },
   "G12": {
     "name": "Grand Av–Newtown",
     "longitude": -73.877223,
-    "latitude": 40.737015
+    "latitude": 40.737015,
+    "borough": "Q"
   },
   "G13": {
     "name": "Elmhurst Av",
     "longitude": -73.882017,
-    "latitude": 40.742454
+    "latitude": 40.742454,
+    "borough": "Q"
   },
   "G14": {
     "name": "Jackson Hts–Roosevelt Av",
     "longitude": -73.891338,
-    "latitude": 40.746644
+    "latitude": 40.746644,
+    "borough": "Q"
   },
   "G15": {
     "name": "65 St",
     "longitude": -73.898453,
-    "latitude": 40.749669
+    "latitude": 40.749669,
+    "borough": "Q"
   },
   "G16": {
     "name": "Northern Blvd",
     "longitude": -73.906006,
-    "latitude": 40.752885
+    "latitude": 40.752885,
+    "borough": "Q"
   },
   "G18": {
     "name": "46 St",
     "longitude": -73.913333,
-    "latitude": 40.756312
+    "latitude": 40.756312,
+    "borough": "Q"
   },
   "G19": {
     "name": "Steinway St",
     "longitude": -73.92074,
-    "latitude": 40.756879
+    "latitude": 40.756879,
+    "borough": "Q"
   },
   "G20": {
     "name": "36 St",
     "longitude": -73.928781,
-    "latitude": 40.752039
+    "latitude": 40.752039,
+    "borough": "Q"
   },
   "G21": {
     "name": "Queens Plaza",
     "longitude": -73.937243,
-    "latitude": 40.748973
+    "latitude": 40.748973,
+    "borough": "Q"
   },
   "F09": {
     "name": "Court Sq–23 St",
     "longitude": -73.946,
-    "latitude": 40.747846
+    "latitude": 40.747846,
+    "borough": "Q"
   },
   "F11": {
     "name": "Lexington Av/53 St",
     "longitude": -73.969055,
-    "latitude": 40.757552
+    "latitude": 40.757552,
+    "borough": "M"
   },
   "F12": {
     "name": "5 Av/53 St",
     "longitude": -73.975224,
-    "latitude": 40.760167
+    "latitude": 40.760167,
+    "borough": "M"
   },
   "D14": {
     "name": "7 Av",
     "longitude": -73.981637,
-    "latitude": 40.762862
+    "latitude": 40.762862,
+    "borough": "M"
   },
   "G05": {
     "name": "Jamaica Center–Parsons/Archer",
     "longitude": -73.801109,
-    "latitude": 40.702147
+    "latitude": 40.702147,
+    "borough": "Q"
   },
   "G06": {
     "name": "Sutphin Blvd–Archer Av–JFK Airport",
     "longitude": -73.807969,
-    "latitude": 40.700486
+    "latitude": 40.700486,
+    "borough": "Q"
   },
   "G07": {
     "name": "Jamaica–Van Wyck",
     "longitude": -73.816859,
-    "latitude": 40.702566
+    "latitude": 40.702566,
+    "borough": "Q"
   },
   "G22": {
     "name": "Court Sq",
     "longitude": -73.943832,
-    "latitude": 40.746554
+    "latitude": 40.746554,
+    "borough": "Q"
   },
   "G24": {
     "name": "21 St",
     "longitude": -73.949724,
-    "latitude": 40.744065
+    "latitude": 40.744065,
+    "borough": "Q"
   },
   "G26": {
     "name": "Greenpoint Av",
     "longitude": -73.954449,
-    "latitude": 40.731352
+    "latitude": 40.731352,
+    "borough": "Bk"
   },
   "G28": {
     "name": "Nassau Av",
     "longitude": -73.951277,
-    "latitude": 40.724635
+    "latitude": 40.724635,
+    "borough": "Bk"
   },
   "G29": {
     "name": "Metropolitan Av",
     "longitude": -73.951418,
-    "latitude": 40.712792
+    "latitude": 40.712792,
+    "borough": "Bk"
   },
   "G30": {
     "name": "Broadway",
     "longitude": -73.950308,
-    "latitude": 40.706092
+    "latitude": 40.706092,
+    "borough": "Bk"
   },
   "G31": {
     "name": "Flushing Av",
     "longitude": -73.950234,
-    "latitude": 40.700377
+    "latitude": 40.700377,
+    "borough": "Bk"
   },
   "G32": {
     "name": "Myrtle–Willoughby Avs",
     "longitude": -73.949046,
-    "latitude": 40.694568
+    "latitude": 40.694568,
+    "borough": "Bk"
   },
   "G33": {
     "name": "Bedford–Nostrand Avs",
     "longitude": -73.953522,
-    "latitude": 40.689627
+    "latitude": 40.689627,
+    "borough": "Bk"
   },
   "G34": {
     "name": "Classon Av",
     "longitude": -73.96007,
-    "latitude": 40.688873
+    "latitude": 40.688873,
+    "borough": "Bk"
   },
   "G35": {
     "name": "Clinton–Washington Avs",
     "longitude": -73.966839,
-    "latitude": 40.688089
+    "latitude": 40.688089,
+    "borough": "Bk"
   },
   "G36": {
     "name": "Fulton St",
     "longitude": -73.975375,
-    "latitude": 40.687119
+    "latitude": 40.687119,
+    "borough": "Bk"
   },
   "101": {
     "name": "Van Cortlandt Park–242 St",
     "longitude": -73.898583,
-    "latitude": 40.889248
+    "latitude": 40.889248,
+    "borough": "Bx"
   },
   "103": {
     "name": "238 St",
     "longitude": -73.90087,
-    "latitude": 40.884667
+    "latitude": 40.884667,
+    "borough": "Bx"
   },
   "104": {
     "name": "231 St",
     "longitude": -73.904834,
-    "latitude": 40.878856
+    "latitude": 40.878856,
+    "borough": "Bx"
   },
   "106": {
     "name": "Marble Hill–225 St",
     "longitude": -73.909831,
-    "latitude": 40.874561
+    "latitude": 40.874561,
+    "borough": "M"
   },
   "107": {
     "name": "215 St",
     "longitude": -73.915279,
-    "latitude": 40.869444
+    "latitude": 40.869444,
+    "borough": "M"
   },
   "108": {
     "name": "207 St",
     "longitude": -73.918822,
-    "latitude": 40.864621
+    "latitude": 40.864621,
+    "borough": "M"
   },
   "109": {
     "name": "Dyckman St",
     "longitude": -73.925536,
-    "latitude": 40.860531
+    "latitude": 40.860531,
+    "borough": "M"
   },
   "110": {
     "name": "191 St",
     "longitude": -73.929412,
-    "latitude": 40.855225
+    "latitude": 40.855225,
+    "borough": "M"
   },
   "111": {
     "name": "181 St",
     "longitude": -73.933596,
-    "latitude": 40.849505
+    "latitude": 40.849505,
+    "borough": "M"
   },
   "112": {
     "name": "168 St–Washington Hts",
     "longitude": -73.940133,
-    "latitude": 40.840556
+    "latitude": 40.840556,
+    "borough": "M"
   },
   "113": {
     "name": "157 St",
     "longitude": -73.94489,
-    "latitude": 40.834041
+    "latitude": 40.834041,
+    "borough": "M"
   },
   "114": {
     "name": "145 St",
     "longitude": -73.95036,
-    "latitude": 40.826551
+    "latitude": 40.826551,
+    "borough": "M"
   },
   "115": {
     "name": "137 St–City College",
     "longitude": -73.953676,
-    "latitude": 40.822008
+    "latitude": 40.822008,
+    "borough": "M"
   },
   "116": {
     "name": "125 St",
     "longitude": -73.958372,
-    "latitude": 40.815581
+    "latitude": 40.815581,
+    "borough": "M"
   },
   "117": {
     "name": "116 St–Columbia University",
     "longitude": -73.96411,
-    "latitude": 40.807722
+    "latitude": 40.807722,
+    "borough": "M"
   },
   "118": {
     "name": "Cathedral Pkwy (110 St)",
     "longitude": -73.966847,
-    "latitude": 40.803967
+    "latitude": 40.803967,
+    "borough": "M"
   },
   "119": {
     "name": "103 St",
     "longitude": -73.968379,
-    "latitude": 40.799446
+    "latitude": 40.799446,
+    "borough": "M"
   },
   "120": {
     "name": "96 St",
     "longitude": -73.972323,
-    "latitude": 40.793919
+    "latitude": 40.793919,
+    "borough": "M"
   },
   "121": {
     "name": "86 St",
     "longitude": -73.976218,
-    "latitude": 40.788644
+    "latitude": 40.788644,
+    "borough": "M"
   },
   "122": {
     "name": "79 St",
     "longitude": -73.979917,
-    "latitude": 40.783934
+    "latitude": 40.783934,
+    "borough": "M"
   },
   "123": {
     "name": "72 St",
     "longitude": -73.98197,
-    "latitude": 40.778453
+    "latitude": 40.778453,
+    "borough": "M"
   },
   "124": {
     "name": "66 St–Lincoln Center",
     "longitude": -73.982209,
-    "latitude": 40.77344
+    "latitude": 40.77344,
+    "borough": "M"
   },
   "125": {
     "name": "59 St–Columbus Circle",
     "longitude": -73.981929,
-    "latitude": 40.768247
+    "latitude": 40.768247,
+    "borough": "M"
   },
   "126": {
     "name": "50 St",
     "longitude": -73.983849,
-    "latitude": 40.761728
+    "latitude": 40.761728,
+    "borough": "M"
   },
   "127": {
     "name": "Times Sq–42 St",
     "longitude": -73.987495,
-    "latitude": 40.75529
+    "latitude": 40.75529,
+    "borough": "M"
   },
   "128": {
     "name": "34 St–Penn Station",
     "longitude": -73.991057,
-    "latitude": 40.750373
+    "latitude": 40.750373,
+    "borough": "M"
   },
   "129": {
     "name": "28 St",
     "longitude": -73.993365,
-    "latitude": 40.747215
+    "latitude": 40.747215,
+    "borough": "M"
   },
   "130": {
     "name": "23 St",
     "longitude": -73.995657,
-    "latitude": 40.744081
+    "latitude": 40.744081,
+    "borough": "M"
   },
   "131": {
     "name": "18 St",
     "longitude": -73.997871,
-    "latitude": 40.74104
+    "latitude": 40.74104,
+    "borough": "M"
   },
   "132": {
     "name": "14 St",
     "longitude": -74.000201,
-    "latitude": 40.737826
+    "latitude": 40.737826,
+    "borough": "M"
   },
   "133": {
     "name": "Christopher St–Sheridan Sq",
     "longitude": -74.002906,
-    "latitude": 40.733422
+    "latitude": 40.733422,
+    "borough": "M"
   },
   "134": {
     "name": "Houston St",
     "longitude": -74.005367,
-    "latitude": 40.728251
+    "latitude": 40.728251,
+    "borough": "M"
   },
   "135": {
     "name": "Canal St",
     "longitude": -74.006277,
-    "latitude": 40.722854
+    "latitude": 40.722854,
+    "borough": "M"
   },
   "136": {
     "name": "Franklin St",
     "longitude": -74.006886,
-    "latitude": 40.719318
+    "latitude": 40.719318,
+    "borough": "M"
   },
   "137": {
     "name": "Chambers St",
     "longitude": -74.009266,
-    "latitude": 40.715478
+    "latitude": 40.715478,
+    "borough": "M"
   },
   "138": {
     "name": "WTC Cortlandt",
     "longitude": -74.012188,
-    "latitude": 40.711835
+    "latitude": 40.711835,
+    "borough": "M"
   },
   "139": {
     "name": "Rector St",
     "longitude": -74.013783,
-    "latitude": 40.707513
+    "latitude": 40.707513,
+    "borough": "M"
   },
   "142": {
     "name": "South Ferry",
     "longitude": -74.013664,
-    "latitude": 40.702068
+    "latitude": 40.702068,
+    "borough": "M"
   },
   "228": {
     "name": "Park Place",
     "longitude": -74.008811,
-    "latitude": 40.713051
+    "latitude": 40.713051,
+    "borough": "M"
   },
   "229": {
     "name": "Fulton St",
     "longitude": -74.006571,
-    "latitude": 40.709416
+    "latitude": 40.709416,
+    "borough": "M"
   },
   "230": {
     "name": "Wall St",
     "longitude": -74.0091,
-    "latitude": 40.706821
+    "latitude": 40.706821,
+    "borough": "M"
   },
   "231": {
     "name": "Clark St",
     "longitude": -73.993086,
-    "latitude": 40.697466
+    "latitude": 40.697466,
+    "borough": "Bk"
   },
   "232": {
     "name": "Borough Hall",
     "longitude": -73.989998,
-    "latitude": 40.693219
+    "latitude": 40.693219,
+    "borough": "Bk"
   },
   "233": {
     "name": "Hoyt St",
     "longitude": -73.985065,
-    "latitude": 40.690545
+    "latitude": 40.690545,
+    "borough": "Bk"
   },
   "234": {
     "name": "Nevins St",
     "longitude": -73.980492,
-    "latitude": 40.688246
+    "latitude": 40.688246,
+    "borough": "Bk"
   },
   "235": {
     "name": "Atlantic Av–Barclays Ctr",
     "longitude": -73.977666,
-    "latitude": 40.684359
+    "latitude": 40.684359,
+    "borough": "Bk"
   },
   "236": {
     "name": "Bergen St",
     "longitude": -73.975098,
-    "latitude": 40.680829
+    "latitude": 40.680829,
+    "borough": "Bk"
   },
   "237": {
     "name": "Grand Army Plaza",
     "longitude": -73.971046,
-    "latitude": 40.675235
+    "latitude": 40.675235,
+    "borough": "Bk"
   },
   "238": {
     "name": "Eastern Pkwy–Brooklyn Museum",
     "longitude": -73.964375,
-    "latitude": 40.671987
+    "latitude": 40.671987,
+    "borough": "Bk"
   },
   "239": {
     "name": "Franklin Avenue–Medgar Evers College",
     "longitude": -73.958131,
-    "latitude": 40.670682
+    "latitude": 40.670682,
+    "borough": "Bk"
   },
   "248": {
     "name": "Nostrand Av",
     "longitude": -73.950466,
-    "latitude": 40.669847
+    "latitude": 40.669847,
+    "borough": "Bk"
   },
   "249": {
     "name": "Kingston Av",
     "longitude": -73.942161,
-    "latitude": 40.669399
+    "latitude": 40.669399,
+    "borough": "Bk"
   },
   "250": {
     "name": "Crown Hts–Utica Av",
     "longitude": -73.932942,
-    "latitude": 40.668897
+    "latitude": 40.668897,
+    "borough": "Bk"
   },
   "251": {
     "name": "Sutter Av–Rutland Rd",
     "longitude": -73.92261,
-    "latitude": 40.664717
+    "latitude": 40.664717,
+    "borough": "Bk"
   },
   "252": {
     "name": "Saratoga Av",
     "longitude": -73.916327,
-    "latitude": 40.661453
+    "latitude": 40.661453,
+    "borough": "Bk"
   },
   "253": {
     "name": "Rockaway Av",
     "longitude": -73.908946,
-    "latitude": 40.662549
+    "latitude": 40.662549,
+    "borough": "Bk"
   },
   "254": {
     "name": "Junius St",
     "longitude": -73.902447,
-    "latitude": 40.663515
+    "latitude": 40.663515,
+    "borough": "Bk"
   },
   "255": {
     "name": "Pennsylvania Av",
     "longitude": -73.894895,
-    "latitude": 40.664635
+    "latitude": 40.664635,
+    "borough": "Bk"
   },
   "256": {
     "name": "Van Siclen Av",
     "longitude": -73.889395,
-    "latitude": 40.665449
+    "latitude": 40.665449,
+    "borough": "Bk"
   },
   "257": {
     "name": "New Lots Av",
     "longitude": -73.884079,
-    "latitude": 40.666235
+    "latitude": 40.666235,
+    "borough": "Bk"
   },
   "241": {
     "name": "President Street–Medgar Evers College",
     "longitude": -73.950683,
-    "latitude": 40.667883
+    "latitude": 40.667883,
+    "borough": "Bk"
   },
   "242": {
     "name": "Sterling St",
     "longitude": -73.95085,
-    "latitude": 40.662742
+    "latitude": 40.662742,
+    "borough": "Bk"
   },
   "243": {
     "name": "Winthrop St",
     "longitude": -73.9502,
-    "latitude": 40.656652
+    "latitude": 40.656652,
+    "borough": "Bk"
   },
   "244": {
     "name": "Church Av",
     "longitude": -73.949575,
-    "latitude": 40.650843
+    "latitude": 40.650843,
+    "borough": "Bk"
   },
   "245": {
     "name": "Beverly Rd",
     "longitude": -73.948959,
-    "latitude": 40.645098
+    "latitude": 40.645098,
+    "borough": "Bk"
   },
   "246": {
     "name": "Newkirk Av–Little Haiti",
     "longitude": -73.948411,
-    "latitude": 40.639967
+    "latitude": 40.639967,
+    "borough": "Bk"
   },
   "247": {
     "name": "Flatbush Av–Brooklyn College",
     "longitude": -73.947642,
-    "latitude": 40.632836
+    "latitude": 40.632836,
+    "borough": "Bk"
   },
   "601": {
     "name": "Pelham Bay Park",
     "longitude": -73.828121,
-    "latitude": 40.852462
+    "latitude": 40.852462,
+    "borough": "Bx"
   },
   "602": {
     "name": "Buhre Av",
     "longitude": -73.832569,
-    "latitude": 40.84681
+    "latitude": 40.84681,
+    "borough": "Bx"
   },
   "603": {
     "name": "Middletown Rd",
     "longitude": -73.836322,
-    "latitude": 40.843863
+    "latitude": 40.843863,
+    "borough": "Bx"
   },
   "604": {
     "name": "Westchester Sq–E Tremont Av",
     "longitude": -73.842952,
-    "latitude": 40.839892
+    "latitude": 40.839892,
+    "borough": "Bx"
   },
   "606": {
     "name": "Zerega Av",
     "longitude": -73.847036,
-    "latitude": 40.836488
+    "latitude": 40.836488,
+    "borough": "Bx"
   },
   "607": {
     "name": "Castle Hill Av",
     "longitude": -73.851222,
-    "latitude": 40.834255
+    "latitude": 40.834255,
+    "borough": "Bx"
   },
   "608": {
     "name": "Parkchester",
     "longitude": -73.860816,
-    "latitude": 40.833226
+    "latitude": 40.833226,
+    "borough": "Bx"
   },
   "609": {
     "name": "St Lawrence Av",
     "longitude": -73.867618,
-    "latitude": 40.831509
+    "latitude": 40.831509,
+    "borough": "Bx"
   },
   "610": {
     "name": "Morrison Av–Soundview",
     "longitude": -73.874516,
-    "latitude": 40.829521
+    "latitude": 40.829521,
+    "borough": "Bx"
   },
   "611": {
     "name": "Elder Av",
     "longitude": -73.879159,
-    "latitude": 40.828584
+    "latitude": 40.828584,
+    "borough": "Bx"
   },
   "612": {
     "name": "Whitlock Av",
     "longitude": -73.886283,
-    "latitude": 40.826525
+    "latitude": 40.826525,
+    "borough": "Bx"
   },
   "613": {
     "name": "Hunts Point Av",
     "longitude": -73.890549,
-    "latitude": 40.820948
+    "latitude": 40.820948,
+    "borough": "Bx"
   },
   "614": {
     "name": "Longwood Av",
     "longitude": -73.896435,
-    "latitude": 40.816104
+    "latitude": 40.816104,
+    "borough": "Bx"
   },
   "615": {
     "name": "E 149 St",
     "longitude": -73.904098,
-    "latitude": 40.812118
+    "latitude": 40.812118,
+    "borough": "Bx"
   },
   "616": {
     "name": "E 143 St–St Mary's St",
     "longitude": -73.907657,
-    "latitude": 40.808719
+    "latitude": 40.808719,
+    "borough": "Bx"
   },
   "617": {
     "name": "Cypress Av",
     "longitude": -73.914042,
-    "latitude": 40.805368
+    "latitude": 40.805368,
+    "borough": "Bx"
   },
   "618": {
     "name": "Brook Av",
     "longitude": -73.91924,
-    "latitude": 40.807566
+    "latitude": 40.807566,
+    "borough": "Bx"
   },
   "619": {
     "name": "3 Av–138 St",
     "longitude": -73.926138,
-    "latitude": 40.810476
+    "latitude": 40.810476,
+    "borough": "Bx"
   },
   "401": {
     "name": "Woodlawn",
     "longitude": -73.878751,
-    "latitude": 40.886037
+    "latitude": 40.886037,
+    "borough": "Bx"
   },
   "402": {
     "name": "Mosholu Pkwy",
     "longitude": -73.884655,
-    "latitude": 40.87975
+    "latitude": 40.87975,
+    "borough": "Bx"
   },
   "405": {
     "name": "Bedford Park Blvd–Lehman College",
     "longitude": -73.890064,
-    "latitude": 40.873412
+    "latitude": 40.873412,
+    "borough": "Bx"
   },
   "406": {
     "name": "Kingsbridge Rd",
     "longitude": -73.897174,
-    "latitude": 40.86776
+    "latitude": 40.86776,
+    "borough": "Bx"
   },
   "407": {
     "name": "Fordham Rd",
     "longitude": -73.901034,
-    "latitude": 40.862803
+    "latitude": 40.862803,
+    "borough": "Bx"
   },
   "408": {
     "name": "183 St",
     "longitude": -73.903879,
-    "latitude": 40.858407
+    "latitude": 40.858407,
+    "borough": "Bx"
   },
   "409": {
     "name": "Burnside Av",
     "longitude": -73.907684,
-    "latitude": 40.853453
+    "latitude": 40.853453,
+    "borough": "Bx"
   },
   "410": {
     "name": "176 St",
     "longitude": -73.911794,
-    "latitude": 40.84848
+    "latitude": 40.84848,
+    "borough": "Bx"
   },
   "411": {
     "name": "Mt Eden Av",
     "longitude": -73.914685,
-    "latitude": 40.844434
+    "latitude": 40.844434,
+    "borough": "Bx"
   },
   "412": {
     "name": "170 St",
     "longitude": -73.917791,
-    "latitude": 40.840075
+    "latitude": 40.840075,
+    "borough": "Bx"
   },
   "413": {
     "name": "167 St",
     "longitude": -73.9214,
-    "latitude": 40.835537
+    "latitude": 40.835537,
+    "borough": "Bx"
   },
   "414": {
     "name": "161 St–Yankee Stadium",
     "longitude": -73.925831,
-    "latitude": 40.827994
+    "latitude": 40.827994,
+    "borough": "Bx"
   },
   "415": {
     "name": "149 St–Grand Concourse",
     "longitude": -73.927351,
-    "latitude": 40.818375
+    "latitude": 40.818375,
+    "borough": "Bx"
   },
   "416": {
     "name": "138 St–Grand Concourse",
     "longitude": -73.929849,
-    "latitude": 40.813224
+    "latitude": 40.813224,
+    "borough": "Bx"
   },
   "621": {
     "name": "125 St",
     "longitude": -73.937594,
-    "latitude": 40.804138
+    "latitude": 40.804138,
+    "borough": "M"
   },
   "622": {
     "name": "116 St",
     "longitude": -73.941617,
-    "latitude": 40.798629
+    "latitude": 40.798629,
+    "borough": "M"
   },
   "623": {
     "name": "110 St",
     "longitude": -73.94425,
-    "latitude": 40.79502
+    "latitude": 40.79502,
+    "borough": "M"
   },
   "624": {
     "name": "103 St",
     "longitude": -73.947478,
-    "latitude": 40.7906
+    "latitude": 40.7906,
+    "borough": "M"
   },
   "625": {
     "name": "96 St",
     "longitude": -73.95107,
-    "latitude": 40.785672
+    "latitude": 40.785672,
+    "borough": "M"
   },
   "626": {
     "name": "86 St",
     "longitude": -73.955589,
-    "latitude": 40.779492
+    "latitude": 40.779492,
+    "borough": "M"
   },
   "627": {
     "name": "77 St",
     "longitude": -73.959874,
-    "latitude": 40.77362
+    "latitude": 40.77362,
+    "borough": "M"
   },
   "628": {
     "name": "68 St–Hunter College",
     "longitude": -73.96387,
-    "latitude": 40.768141
+    "latitude": 40.768141,
+    "borough": "M"
   },
   "629": {
     "name": "59 St",
     "longitude": -73.967967,
-    "latitude": 40.762526
+    "latitude": 40.762526,
+    "borough": "M"
   },
   "630": {
     "name": "51 St",
     "longitude": -73.97192,
-    "latitude": 40.757107
+    "latitude": 40.757107,
+    "borough": "M"
   },
   "631": {
     "name": "Grand Central–42 St",
     "longitude": -73.976848,
-    "latitude": 40.751776
+    "latitude": 40.751776,
+    "borough": "M"
   },
   "632": {
     "name": "33 St",
     "longitude": -73.982076,
-    "latitude": 40.746081
+    "latitude": 40.746081,
+    "borough": "M"
   },
   "633": {
     "name": "28 St",
     "longitude": -73.984264,
-    "latitude": 40.74307
+    "latitude": 40.74307,
+    "borough": "M"
   },
   "634": {
     "name": "23 St",
     "longitude": -73.986599,
-    "latitude": 40.739864
+    "latitude": 40.739864,
+    "borough": "M"
   },
   "635": {
     "name": "14 St–Union Sq",
     "longitude": -73.989951,
-    "latitude": 40.734673
+    "latitude": 40.734673,
+    "borough": "M"
   },
   "636": {
     "name": "Astor Pl",
     "longitude": -73.99107,
-    "latitude": 40.730054
+    "latitude": 40.730054,
+    "borough": "M"
   },
   "637": {
     "name": "Bleecker St",
     "longitude": -73.994659,
-    "latitude": 40.725915
+    "latitude": 40.725915,
+    "borough": "M"
   },
   "638": {
     "name": "Spring St",
     "longitude": -73.997141,
-    "latitude": 40.722301
+    "latitude": 40.722301,
+    "borough": "M"
   },
   "639": {
     "name": "Canal St",
     "longitude": -74.000193,
-    "latitude": 40.718803
+    "latitude": 40.718803,
+    "borough": "M"
   },
   "640": {
     "name": "Brooklyn Bridge–City Hall",
     "longitude": -74.004131,
-    "latitude": 40.713065
+    "latitude": 40.713065,
+    "borough": "M"
   },
   "418": {
     "name": "Fulton St",
     "longitude": -74.009509,
-    "latitude": 40.710368
+    "latitude": 40.710368,
+    "borough": "M"
   },
   "419": {
     "name": "Wall St",
     "longitude": -74.011862,
-    "latitude": 40.707557
+    "latitude": 40.707557,
+    "borough": "M"
   },
   "420": {
     "name": "Bowling Green",
     "longitude": -74.014065,
-    "latitude": 40.704817
+    "latitude": 40.704817,
+    "borough": "M"
   },
   "423": {
     "name": "Borough Hall",
     "longitude": -73.990151,
-    "latitude": 40.692404
+    "latitude": 40.692404,
+    "borough": "Bk"
   },
   "201": {
     "name": "Wakefield–241 St",
     "longitude": -73.85062,
-    "latitude": 40.903125
+    "latitude": 40.903125,
+    "borough": "Bx"
   },
   "204": {
     "name": "Nereid Av",
     "longitude": -73.854376,
-    "latitude": 40.898379
+    "latitude": 40.898379,
+    "borough": "Bx"
   },
   "205": {
     "name": "233 St",
     "longitude": -73.857473,
-    "latitude": 40.893193
+    "latitude": 40.893193,
+    "borough": "Bx"
   },
   "206": {
     "name": "225 St",
     "longitude": -73.860341,
-    "latitude": 40.888022
+    "latitude": 40.888022,
+    "borough": "Bx"
   },
   "207": {
     "name": "219 St",
     "longitude": -73.862633,
-    "latitude": 40.883895
+    "latitude": 40.883895,
+    "borough": "Bx"
   },
   "208": {
     "name": "Gun Hill Rd",
     "longitude": -73.866256,
-    "latitude": 40.87785
+    "latitude": 40.87785,
+    "borough": "Bx"
   },
   "209": {
     "name": "Burke Av",
     "longitude": -73.867164,
-    "latitude": 40.871356
+    "latitude": 40.871356,
+    "borough": "Bx"
   },
   "210": {
     "name": "Allerton Av",
     "longitude": -73.867352,
-    "latitude": 40.865462
+    "latitude": 40.865462,
+    "borough": "Bx"
   },
   "211": {
     "name": "Pelham Pkwy",
     "longitude": -73.867615,
-    "latitude": 40.857192
+    "latitude": 40.857192,
+    "borough": "Bx"
   },
   "212": {
     "name": "Bronx Park East",
     "longitude": -73.868457,
-    "latitude": 40.848828
+    "latitude": 40.848828,
+    "borough": "Bx"
   },
   "213": {
     "name": "E 180 St",
     "longitude": -73.873488,
-    "latitude": 40.841894
+    "latitude": 40.841894,
+    "borough": "Bx"
   },
   "214": {
     "name": "West Farms Sq–E Tremont Av",
     "longitude": -73.880049,
-    "latitude": 40.840295
+    "latitude": 40.840295,
+    "borough": "Bx"
   },
   "215": {
     "name": "174 St",
     "longitude": -73.887734,
-    "latitude": 40.837288
+    "latitude": 40.837288,
+    "borough": "Bx"
   },
   "216": {
     "name": "Freeman St",
     "longitude": -73.891865,
-    "latitude": 40.829993
+    "latitude": 40.829993,
+    "borough": "Bx"
   },
   "217": {
     "name": "Simpson St",
     "longitude": -73.893064,
-    "latitude": 40.824073
+    "latitude": 40.824073,
+    "borough": "Bx"
   },
   "218": {
     "name": "Intervale Av",
     "longitude": -73.896736,
-    "latitude": 40.822181
+    "latitude": 40.822181,
+    "borough": "Bx"
   },
   "219": {
     "name": "Prospect Av",
     "longitude": -73.90177,
-    "latitude": 40.819585
+    "latitude": 40.819585,
+    "borough": "Bx"
   },
   "220": {
     "name": "Jackson Av",
     "longitude": -73.907807,
-    "latitude": 40.81649
+    "latitude": 40.81649,
+    "borough": "Bx"
   },
   "221": {
     "name": "3 Av–149 St",
     "longitude": -73.917757,
-    "latitude": 40.816109
+    "latitude": 40.816109,
+    "borough": "Bx"
   },
   "222": {
     "name": "149 St–Grand Concourse",
     "longitude": -73.926718,
-    "latitude": 40.81841
+    "latitude": 40.81841,
+    "borough": "Bx"
   },
   "301": {
     "name": "Harlem–148 St",
     "longitude": -73.93647,
-    "latitude": 40.82388
+    "latitude": 40.82388,
+    "borough": "M"
   },
   "302": {
     "name": "145 St",
     "longitude": -73.936245,
-    "latitude": 40.820421
+    "latitude": 40.820421,
+    "borough": "M"
   },
   "224": {
     "name": "135 St",
     "longitude": -73.94077,
-    "latitude": 40.814229
+    "latitude": 40.814229,
+    "borough": "M"
   },
   "225": {
     "name": "125 St",
     "longitude": -73.945495,
-    "latitude": 40.807754
+    "latitude": 40.807754,
+    "borough": "M"
   },
   "226": {
     "name": "116 St",
     "longitude": -73.949625,
-    "latitude": 40.802098
+    "latitude": 40.802098,
+    "borough": "M"
   },
   "227": {
     "name": "Central Park North (110 St)",
     "longitude": -73.951822,
-    "latitude": 40.799075
+    "latitude": 40.799075,
+    "borough": "M"
   },
   "501": {
     "name": "Eastchester–Dyre Av",
     "longitude": -73.830834,
-    "latitude": 40.8883
+    "latitude": 40.8883,
+    "borough": "Bx"
   },
   "502": {
     "name": "Baychester Av",
     "longitude": -73.838591,
-    "latitude": 40.878663
+    "latitude": 40.878663,
+    "borough": "Bx"
   },
   "503": {
     "name": "Gun Hill Rd",
     "longitude": -73.846384,
-    "latitude": 40.869526
+    "latitude": 40.869526,
+    "borough": "Bx"
   },
   "504": {
     "name": "Pelham Pkwy",
     "longitude": -73.855359,
-    "latitude": 40.858985
+    "latitude": 40.858985,
+    "borough": "Bx"
   },
   "505": {
     "name": "Morris Park",
     "longitude": -73.860495,
-    "latitude": 40.854364
+    "latitude": 40.854364,
+    "borough": "Bx"
   },
   "701": {
     "name": "Flushing–Main St",
     "longitude": -73.83003,
-    "latitude": 40.7596
+    "latitude": 40.7596,
+    "borough": "Q"
   },
   "702": {
     "name": "Mets–Willets Point",
     "longitude": -73.845625,
-    "latitude": 40.754622
+    "latitude": 40.754622,
+    "borough": "Q"
   },
   "705": {
     "name": "111 St",
     "longitude": -73.855334,
-    "latitude": 40.75173
+    "latitude": 40.75173,
+    "borough": "Q"
   },
   "706": {
     "name": "103 St–Corona Plaza",
     "longitude": -73.8627,
-    "latitude": 40.749865
+    "latitude": 40.749865,
+    "borough": "Q"
   },
   "707": {
     "name": "Junction Blvd",
     "longitude": -73.869527,
-    "latitude": 40.749145
+    "latitude": 40.749145,
+    "borough": "Q"
   },
   "708": {
     "name": "90 St–Elmhurst Av",
     "longitude": -73.876613,
-    "latitude": 40.748408
+    "latitude": 40.748408,
+    "borough": "Q"
   },
   "709": {
     "name": "82 St–Jackson Hts",
     "longitude": -73.883697,
-    "latitude": 40.747659
+    "latitude": 40.747659,
+    "borough": "Q"
   },
   "710": {
     "name": "74 St–Broadway",
     "longitude": -73.891394,
-    "latitude": 40.746848
+    "latitude": 40.746848,
+    "borough": "Q"
   },
   "711": {
     "name": "69 St",
     "longitude": -73.896403,
-    "latitude": 40.746325
+    "latitude": 40.746325,
+    "borough": "Q"
   },
   "712": {
     "name": "Woodside–61 St",
     "longitude": -73.902984,
-    "latitude": 40.74563
+    "latitude": 40.74563,
+    "borough": "Q"
   },
   "713": {
     "name": "52 St",
     "longitude": -73.912549,
-    "latitude": 40.744149
+    "latitude": 40.744149,
+    "borough": "Q"
   },
   "714": {
     "name": "46 St–Bliss St",
     "longitude": -73.918435,
-    "latitude": 40.743132
+    "latitude": 40.743132,
+    "borough": "Q"
   },
   "715": {
     "name": "40 St–Lowery St",
     "longitude": -73.924016,
-    "latitude": 40.743781
+    "latitude": 40.743781,
+    "borough": "Q"
   },
   "716": {
     "name": "33 St–Rawson St",
     "longitude": -73.930997,
-    "latitude": 40.744587
+    "latitude": 40.744587,
+    "borough": "Q"
   },
   "718": {
     "name": "Queensboro Plaza",
     "longitude": -73.940202,
-    "latitude": 40.750582
+    "latitude": 40.750582,
+    "borough": "Q"
   },
   "R09": {
     "name": "Queensboro Plaza",
     "longitude": -73.940202,
-    "latitude": 40.750582
+    "latitude": 40.750582,
+    "borough": "Q"
   },
   "719": {
     "name": "Court Sq",
     "longitude": -73.945264,
-    "latitude": 40.747023
+    "latitude": 40.747023,
+    "borough": "Q"
   },
   "720": {
     "name": "Hunters Point Av",
     "longitude": -73.948916,
-    "latitude": 40.742216
+    "latitude": 40.742216,
+    "borough": "Q"
   },
   "721": {
     "name": "Vernon Blvd–Jackson Av",
     "longitude": -73.953581,
-    "latitude": 40.742626
+    "latitude": 40.742626,
+    "borough": "Q"
   },
   "723": {
     "name": "Grand Central–42 St",
     "longitude": -73.976041,
-    "latitude": 40.751431
+    "latitude": 40.751431,
+    "borough": "M"
   },
   "724": {
     "name": "5 Av",
     "longitude": -73.981963,
-    "latitude": 40.753821
+    "latitude": 40.753821,
+    "borough": "M"
   },
   "725": {
     "name": "Times Sq–42 St",
     "longitude": -73.987691,
-    "latitude": 40.755477
+    "latitude": 40.755477,
+    "borough": "M"
   },
   "902": {
     "name": "Times Sq–42 St",
     "longitude": -73.986229,
-    "latitude": 40.755983
+    "latitude": 40.755983,
+    "borough": "M"
   },
   "901": {
     "name": "Grand Central–42 St",
     "longitude": -73.979189,
-    "latitude": 40.752769
+    "latitude": 40.752769,
+    "borough": "M"
   },
   "726": {
     "name": "34 St–Hudson Yards",
     "longitude": -74.00191,
-    "latitude": 40.755882
+    "latitude": 40.755882,
+    "borough": "M"
   },
   "Q05": {
     "name": "96 St",
     "longitude": -73.947152,
-    "latitude": 40.784318
+    "latitude": 40.784318,
+    "borough": "M"
   },
   "Q04": {
     "name": "86 St",
     "longitude": -73.951787,
-    "latitude": 40.777891
+    "latitude": 40.777891,
+    "borough": "M"
   },
   "Q03": {
     "name": "72 St",
     "longitude": -73.958424,
-    "latitude": 40.768799
+    "latitude": 40.768799,
+    "borough": "M"
   },
   "S31": {
     "name": "St George",
     "longitude": -74.073643,
-    "latitude": 40.643748
+    "latitude": 40.643748,
+    "borough": "SI"
   },
   "S30": {
     "name": "Tompkinsville",
     "longitude": -74.074835,
-    "latitude": 40.636949
+    "latitude": 40.636949,
+    "borough": "SI"
   },
   "S29": {
     "name": "Stapleton",
     "longitude": -74.075162,
-    "latitude": 40.627915
+    "latitude": 40.627915,
+    "borough": "SI"
   },
   "S28": {
     "name": "Clifton",
     "longitude": -74.071402,
-    "latitude": 40.621319
+    "latitude": 40.621319,
+    "borough": "SI"
   },
   "S27": {
     "name": "Grasmere",
     "longitude": -74.084087,
-    "latitude": 40.603117
+    "latitude": 40.603117,
+    "borough": "SI"
   },
   "S26": {
     "name": "Old Town",
     "longitude": -74.087368,
-    "latitude": 40.596612
+    "latitude": 40.596612,
+    "borough": "SI"
   },
   "S25": {
     "name": "Dongan Hills",
     "longitude": -74.09609,
-    "latitude": 40.588849
+    "latitude": 40.588849,
+    "borough": "SI"
   },
   "S24": {
     "name": "Jefferson Av",
     "longitude": -74.103338,
-    "latitude": 40.583591
+    "latitude": 40.583591,
+    "borough": "SI"
   },
   "S23": {
     "name": "Grant City",
     "longitude": -74.109704,
-    "latitude": 40.578965
+    "latitude": 40.578965,
+    "borough": "SI"
   },
   "S22": {
     "name": "New Dorp",
     "longitude": -74.11721,
-    "latitude": 40.57348
+    "latitude": 40.57348,
+    "borough": "SI"
   },
   "S21": {
     "name": "Oakwood Heights",
     "longitude": -74.12632,
-    "latitude": 40.56511
+    "latitude": 40.56511,
+    "borough": "SI"
   },
   "S20": {
     "name": "Bay Terrace",
     "longitude": -74.136907,
-    "latitude": 40.5564
+    "latitude": 40.5564,
+    "borough": "SI"
   },
   "S19": {
     "name": "Great Kills",
     "longitude": -74.151399,
-    "latitude": 40.551231
+    "latitude": 40.551231,
+    "borough": "SI"
   },
   "S18": {
     "name": "Eltingville",
     "longitude": -74.16457,
-    "latitude": 40.544601
+    "latitude": 40.544601,
+    "borough": "SI"
   },
   "S17": {
     "name": "Annadale",
     "longitude": -74.178217,
-    "latitude": 40.54046
+    "latitude": 40.54046,
+    "borough": "SI"
   },
   "S16": {
     "name": "Huguenot",
     "longitude": -74.191794,
-    "latitude": 40.533674
+    "latitude": 40.533674,
+    "borough": "SI"
   },
   "S15": {
     "name": "Prince's Bay",
     "longitude": -74.200064,
-    "latitude": 40.525507
+    "latitude": 40.525507,
+    "borough": "SI"
   },
   "S14": {
     "name": "Pleasant Plains",
     "longitude": -74.217847,
-    "latitude": 40.52241
+    "latitude": 40.52241,
+    "borough": "SI"
   },
   "S13": {
     "name": "Richmond Valley",
     "longitude": -74.229141,
-    "latitude": 40.519631
+    "latitude": 40.519631,
+    "borough": "SI"
   },
   "S09": {
     "name": "Tottenville",
     "longitude": -74.251961,
-    "latitude": 40.512764
+    "latitude": 40.512764,
+    "borough": "SI"
   },
   "S11": {
     "name": "Arthur Kill",
     "longitude": -74.242096,
-    "latitude": 40.516578
+    "latitude": 40.516578,
+    "borough": "SI"
   }
 }


### PR DESCRIPTION
Hey! Big fan of what you were doing here and have been playing with friends almost every day. 

One thing we have had trouble with is knowing the difference between stations that are totally different boroughs but share a name (i.e. there are 3 7th Avenue stations) I just made a quick change for you to check out how the game feels after revealing the boros of the origin and destination in the hint.

I also noticed a small linux compatibility bug (probably works in OSX because of [APFS](https://apple.stackexchange.com/questions/415613/what-is-the-default-partition-type-case-sensitive-or-insensitive-in-macbook-pr)) where you look for a lowercase `stations.csv` but the default filename (and instructions) are looking for `Stations.csv` 

Anyway, keep up the good work and please let me know if theres any way I can help out whenever!